### PR TITLE
Fix expires_in type

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -127,7 +127,7 @@ export interface TokenResponse {
   access_token: string;
 
   /** The lifetime in seconds of the access token. */
-  expires_in: string;
+  expires_in: number;
 
   /** The hosted domain the signed-in user belongs to. */
   hd?: string;


### PR DESCRIPTION
Wrong type for the `expires_in` key in the `TokenResponse` interface.