### PR TITLE
added an optional onClick prop into GoogleLogin component

### DIFF
--- a/packages/@react-oauth/google/src/GoogleLogin.tsx
+++ b/packages/@react-oauth/google/src/GoogleLogin.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, type MouseEventHandler } from 'react';
 
 import { useGoogleOAuth } from './GoogleOAuthProvider';
 import {
@@ -15,6 +15,7 @@ export type GoogleLoginProps = {
   onError?: () => void;
   promptMomentNotification?: MomenListener;
   useOneTap?: boolean;
+  onClick?: MouseEventHandler;
 } & Omit<IdConfiguration, 'client_id' | 'callback'> &
   GsiButtonConfiguration;
 
@@ -22,6 +23,7 @@ export default function GoogleLogin({
   onSuccess,
   onError,
   useOneTap,
+  onClick,
   promptMomentNotification,
   type = 'standard',
   theme = 'outline',
@@ -73,6 +75,8 @@ export default function GoogleLogin({
 
     if (useOneTap)
       window.google?.accounts.id.prompt(promptMomentNotificationRef.current);
+
+    onClick && btnContainerRef.current.addEventListener("click", onClick);
 
     return () => {
       if (useOneTap) window.google?.accounts.id.cancel();


### PR DESCRIPTION
I needed **an optional onClick prop** for the GoogleLogin component in order to do some ui actions (like cleaning the error message on the screen etc.).

For this reason, I added `an additional click eventlistener` for the rendered div in the component.