### PR TITLE
Fixed wrong copied code in CodeFlow

### DIFF
--- a/apps/playground/src/components/CodeFlow.tsx
+++ b/apps/playground/src/components/CodeFlow.tsx
@@ -6,16 +6,17 @@ import CodeBlock from './CodeBlock';
 
 const code = `
 const googleLogin = useGoogleLogin({
-  onSuccess: async (tokenResponse) => {
-    console.log(tokenResponse);
-    const userInfo = await axios.get(
-      'https://www.googleapis.com/oauth2/v3/userinfo',
-      { headers: { Authorization: 'Bearer <tokenResponse.access_token>' } },
-    );
+    flow: 'auth-code',
+    onSuccess: async (codeResponse) => {
+        console.log(codeResponse);
+        const tokens = await axios.post(
+            'http://localhost:3001/auth/google', {
+                code: codeResponse.code,
+            });
 
-    console.log(userInfo);
-  },
-  onError: errorResponse => console.log(errorResponse),
+        console.log(tokens);
+    },
+    onError: errorResponse => console.log(errorResponse),
 });
 `;
 


### PR DESCRIPTION
Here is a fix for wrong copied code in CodeFlow.
To reproduce the issue, open https://react-oauth.vercel.app/ and select Authorization -> Authorization Code Flow. Then, copy the code sample presented. The image you see is from https://github.com/MomenSherif/react-oauth/blob/master/apps/playground/public/images/Code-snap.png but the copied code is THE SAME AS THE ONE GENERATED FOR **Implicit** flow