### PR TITLE
Added missing string literal types to prompt in OverridableTokenClientConfig

### DIFF
--- a/packages/@react-oauth/google/src/types/index.ts
+++ b/packages/@react-oauth/google/src/types/index.ts
@@ -219,7 +219,7 @@ export interface OverridableTokenClientConfig {
   /**
    * Optional. A space-delimited, case-sensitive list of prompts to present the user.
    */
-  prompt?: string;
+  prompt?: '' | 'none' | 'consent' | 'select_account';
 
   /**
    * Optional. If set to false,


### PR DESCRIPTION
Added full type definition for the "prompt" property in OverridableTokenClientConfig which is identical to the one in TokenClientConfig.

Docs for reference: https://developers.google.com/identity/oauth2/web/reference/js-reference#OverridableTokenClientConfig