### PR TITLE
Add instructions for accessing data with useGoogleLogin()

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ const login = useGoogleLogin({
   Sign in with Google 🚀{' '}
 </MyCustomButton>;
 ```
+To access the user data fetch
+```
+https://www.googleapis.com/oauth2/v3/userinfo?access_token=<the access token from the useGoogleLogin() tokenResponse>
+```
 
 #### Authorization code flow
 


### PR DESCRIPTION
Adding instructions for getting user info with the `useGoogleLogin()` hook from `https://www.googleapis.com/oauth2/v3/userinfo
`
The naming suggests that the response will be the same as with the `GoogleLogin` component, but it is not.

`GoogleLogin` returns a JWT and `useGoogleLogin()` returns an access token.