### PR TITLE
Add type to GSI client script tag

### DIFF
--- a/packages/@react-oauth/google/src/hooks/useLoadGsiScript.ts
+++ b/packages/@react-oauth/google/src/hooks/useLoadGsiScript.ts
@@ -28,6 +28,7 @@ export default function useLoadGsiScript(
   useEffect(() => {
     const scriptTag = document.createElement('script');
     scriptTag.src = 'https://accounts.google.com/gsi/client';
+    scriptTag.type = 'text/javascript';
     scriptTag.async = true;
     scriptTag.defer = true;
     scriptTag.onload = () => {


### PR DESCRIPTION
This prevents the following error in WKWebView
Refused to execute https://accounts.google.com/gsi/client as script because "X-Content-Type-Options: nosniff" was given and its Content-Type is not a script MIME type.