### PR TITLE
Add support for `click_listener` in `GsiButtonConfiguration`

### DIFF
--- a/.changeset/fuzzy-parrots-help.md
+++ b/.changeset/fuzzy-parrots-help.md
@@ -1,0 +1,5 @@
+---
+'@react-oauth/google': minor
+---
+
+add click_listener for GoogleLogin button

--- a/packages/@react-oauth/google/src/GoogleLogin.tsx
+++ b/packages/@react-oauth/google/src/GoogleLogin.tsx
@@ -33,6 +33,7 @@ export default function GoogleLogin({
   logo_alignment,
   width,
   locale,
+  click_listener,
   ...props
 }: GoogleLoginProps) {
   const btnContainerRef = useRef<HTMLDivElement>(null);
@@ -76,6 +77,7 @@ export default function GoogleLogin({
       logo_alignment,
       width,
       locale,
+      click_listener,
     });
 
     if (useOneTap)

--- a/packages/@react-oauth/google/src/google-auth-window.d.ts
+++ b/packages/@react-oauth/google/src/google-auth-window.d.ts
@@ -7,7 +7,6 @@ interface Window {
         renderButton: (
           parent: HTMLElement,
           options: GsiButtonConfiguration,
-          clickHandler?: () => void,
         ) => void;
         disableAutoSelect: () => void;
         storeCredential: (

--- a/packages/@react-oauth/google/src/types/index.ts
+++ b/packages/@react-oauth/google/src/types/index.ts
@@ -88,6 +88,8 @@ export interface GsiButtonConfiguration {
   width?: string;
   /** If set, then the button [language](https://developers.google.com/identity/gsi/web/reference/js-reference#locale) is rendered */
   locale?: string;
+  /** If set, this [function](https://developers.google.com/identity/gsi/web/reference/js-reference#click_listener) will be called when the Sign in with Google button is clicked. */
+  click_listener?: () => void;
 }
 
 export interface PromptMomentNotification {


### PR DESCRIPTION
Google has added a new `click_listener` option to the `GsiButtonConfiguration` that allows users to specify a function to be called when the Sign in with Google button is called. Adding support for this property enables users of the library to recognize the start of an authentication flow, based on which other components' state may be reset.

Refs https://developers.google.com/identity/gsi/web/reference/js-reference#click_listener

Closes https://github.com/MomenSherif/react-oauth/issues/40