### PR TITLE
Fix #183: useGoogleLogin won't return id_token doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ useGoogleOneTapLogin({
 
 ### Custom login button (implicit & authorization code flow)
 
+You can use `useGoogleLogin` hook to obtain access and refresh tokens directly, or get auth code to later exchange it to other tokens.
+Note that this hook does not return `id_token`.
+
 #### Implicit flow
 
 ```jsx

--- a/README.md
+++ b/README.md
@@ -131,8 +131,9 @@ useGoogleOneTapLogin({
 
 ### Custom login button (implicit & authorization code flow)
 
-You can use `useGoogleLogin` hook to obtain access and refresh tokens directly, or get auth code to later exchange it to other tokens.
-Note that this hook does not return `id_token`.
+You can use `useGoogleLogin` hook to obtain access and refresh tokens directly using `implicit` flow,
+or obtain auth code to later exchange it to other tokens with `auth-code` flow.
+Note that this hook is not designed to return `id_token`, use `GoogleLogin` or token exchange instead.
 
 #### Implicit flow
 

--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ useGoogleOneTapLogin({
 
 ### Custom login button (implicit & authorization code flow)
 
-You can use `useGoogleLogin` hook to obtain access and refresh tokens directly using `implicit` flow,
-or obtain auth code to later exchange it to other tokens with `auth-code` flow.
-Note that this hook is not designed to return `id_token`, use `GoogleLogin` or token exchange instead.
+You can use `useGoogleLogin` hook to obtain access token directly using `implicit` flow,
+or obtain auth code to later exchange it to other tokens using `auth-code` flow.
+Note that this hook isn't designed to return `id_token`, use `GoogleLogin` component or `auth-code` flow with token exchange instead.
 
 #### Implicit flow
 


### PR DESCRIPTION
This adds a line of clarifying documentation that will save lib user's time. I personally spent a while to figure out that id_token is not designed to be returned by `useGoogleLogin` when migrating to the "new" Google oAuth flow.

Same for other people:

- #183 #175 #162 #151 #145 #130 #113 [etc](https://github.com/MomenSherif/react-oauth/issues?q=id+token)

Feel free to suggest a better wording or how-to.