### PR TITLE
pass id & classname props to div to allow styling from css

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
     "commitizen": {
       "path": "cz-conventional-changelog"
     }
+  },
+  "dependencies": {
+    "changeset": "^0.2.6"
   }
 }

--- a/packages/@react-oauth/google/src/GoogleLogin.tsx
+++ b/packages/@react-oauth/google/src/GoogleLogin.tsx
@@ -13,6 +13,8 @@ import {
 const containerHeightMap = { large: 40, medium: 32, small: 20 };
 
 export type GoogleLoginProps = {
+  id?: string;
+  className?: string;
   onSuccess: (credentialResponse: CredentialResponse) => void;
   onError?: () => void;
   promptMomentNotification?: MomenListener;
@@ -21,6 +23,8 @@ export type GoogleLoginProps = {
   GsiButtonConfiguration;
 
 export default function GoogleLogin({
+  id,
+  className,
   onSuccess,
   onError,
   useOneTap,
@@ -102,6 +106,11 @@ export default function GoogleLogin({
   ]);
 
   return (
-    <div ref={btnContainerRef} style={{ height: containerHeightMap[size] }} />
+    <div
+      id={id}
+      className={className}
+      ref={btnContainerRef}
+      style={{ height: containerHeightMap[size] }}
+    />
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4228,6 +4228,14 @@ chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.2:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+changeset@^0.2.6:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/changeset/-/changeset-0.2.6.tgz#6e6f3df72b41ef8915db25a22e16b00c8c93f003"
+  integrity sha512-d21ym9zLPOKMVhIa8ulJo5IV3QR2NNdK6BWuwg48qJA0XSQaMeDjo1UGThcTn7YDmU08j3UpKyFNvb3zplk8mw==
+  dependencies:
+    udc "^1.0.0"
+    underscore "^1.8.3"
+
 char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
@@ -11149,6 +11157,11 @@ typescript@^4.4.3, typescript@^4.6.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
   integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
 
+udc@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/udc/-/udc-1.0.1.tgz#c5e62448acf35eaa524d5c3698c863a5bac46bfc"
+  integrity sha512-jv+D9de1flsum5QkFtBdjyppCQAdz9kTck/0xST5Vx48T9LL2BYnw0Iw77dSKDQ9KZ/PS3qPO1vfXHDpLZlxcQ==
+
 unbox-primitive@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.2.tgz#29032021057d5e6cdbd08c5129c226dff8ed6f9e"
@@ -11158,6 +11171,11 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
+
+underscore@^1.8.3:
+  version "1.13.6"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.6.tgz#04786a1f589dc6c09f761fc5f45b89e935136441"
+  integrity sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Hello @MomenSherif
I'm taking over @gwuah's initial PR, where he made changes about 
ids and classnames being passed as props to div to allow styling from css.
You mentioned something about adding a changeset file with patch update in order to merge it.
Could you please provide some guidance on how to do that? Thank you.