### PR TITLE
Add support for CSP nonce on GSI script & inline styles

### DIFF
--- a/.changeset/old-rats-unite.md
+++ b/.changeset/old-rats-unite.md
@@ -1,0 +1,5 @@
+---
+'@react-oauth/google': patch
+---
+
+Add minor CSP support by accepting "nonce" and propagating it to GSI script & inline style

--- a/README.md
+++ b/README.md
@@ -192,8 +192,8 @@ const hasAccess = hasGrantedAnyScopeGoogle(
 
 | Required | Prop                | Type       | Description                                                                 |
 | :------: | ------------------- | ---------- | --------------------------------------------------------------------------- |
-|    ✓     | clientId            | `string`   | [**Google API client ID**](https://console.cloud.google.com/apis/dashboard)  |
-|          | nonce               | `string`   | Nonce applied to GSI script tag. Propagates to GSI's inline style tag      |
+|    ✓     | clientId            | `string`   | [**Google API client ID**](https://console.cloud.google.com/apis/dashboard) |
+|          | nonce               | `string`   | Nonce applied to GSI script tag. Propagates to GSI's inline style tag       |
 |          | onScriptLoadSuccess | `function` | Callback fires on load gsi script success                                   |
 |          | onScriptLoadError   | `function` | Callback fires on load gsi script failure                                   |
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,8 @@ const hasAccess = hasGrantedAnyScopeGoogle(
 
 | Required | Prop                | Type       | Description                                                                 |
 | :------: | ------------------- | ---------- | --------------------------------------------------------------------------- |
-|    ✓     | clientId            | `string`   | [**Google API client ID**](https://console.cloud.google.com/apis/dashboard) |
+|    ✓     | clientId            | `string`   | [**Google API client ID**](https://console.cloud.google.com/apis/dashboard)  |
+|          | nonce               | `string`   | Nonce applied to GSI script tag. Propagates to GSI's inline style tag      |
 |          | onScriptLoadSuccess | `function` | Callback fires on load gsi script success                                   |
 |          | onScriptLoadError   | `function` | Callback fires on load gsi script failure                                   |
 

--- a/packages/@react-oauth/google/src/GoogleOAuthProvider.tsx
+++ b/packages/@react-oauth/google/src/GoogleOAuthProvider.tsx
@@ -18,11 +18,13 @@ interface GoogleOAuthProviderProps extends UseLoadGsiScriptOptions {
 
 export default function GoogleOAuthProvider({
   clientId,
+  nonce,
   onScriptLoadSuccess,
   onScriptLoadError,
   children,
 }: GoogleOAuthProviderProps) {
   const scriptLoadedSuccessfully = useLoadGsiScript({
+    nonce,
     onScriptLoadSuccess,
     onScriptLoadError,
   });

--- a/packages/@react-oauth/google/src/hooks/useLoadGsiScript.ts
+++ b/packages/@react-oauth/google/src/hooks/useLoadGsiScript.ts
@@ -49,7 +49,7 @@ export default function useLoadGsiScript(
     return () => {
       document.body.removeChild(scriptTag);
     };
-  }, []);
+  }, [nonce]);
 
   return scriptLoadedSuccessfully;
 }

--- a/packages/@react-oauth/google/src/hooks/useLoadGsiScript.ts
+++ b/packages/@react-oauth/google/src/hooks/useLoadGsiScript.ts
@@ -2,6 +2,10 @@ import { useState, useEffect, useRef } from 'react';
 
 export interface UseLoadGsiScriptOptions {
   /**
+   * Nonce applied to GSI script tag. Propagates to GSI's inline style tag
+   */
+  nonce?: string;
+  /**
    * Callback fires on load [gsi](https://accounts.google.com/gsi/client) script success
    */
   onScriptLoadSuccess?: () => void;
@@ -14,7 +18,7 @@ export interface UseLoadGsiScriptOptions {
 export default function useLoadGsiScript(
   options: UseLoadGsiScriptOptions = {},
 ): boolean {
-  const { onScriptLoadSuccess, onScriptLoadError } = options;
+  const { nonce, onScriptLoadSuccess, onScriptLoadError } = options;
 
   const [scriptLoadedSuccessfully, setScriptLoadedSuccessfully] =
     useState(false);
@@ -30,6 +34,7 @@ export default function useLoadGsiScript(
     scriptTag.src = 'https://accounts.google.com/gsi/client';
     scriptTag.async = true;
     scriptTag.defer = true;
+    scriptTag.nonce = nonce;
     scriptTag.onload = () => {
       setScriptLoadedSuccessfully(true);
       onScriptLoadSuccessRef.current?.();


### PR DESCRIPTION
Implements suggestions from #229.

Allow passing `nonce` to `GoogleOAuthProvider` in order to have it propagated to GSI script & inline styles