### PR TITLE
fix: fix issue where trying to read oauth2 of undefined accounts throws an error

### DIFF
--- a/packages/@react-oauth/google/src/hooks/useGoogleLogin.ts
+++ b/packages/@react-oauth/google/src/hooks/useGoogleLogin.ts
@@ -96,7 +96,7 @@ export default function useGoogleLogin({
     const clientMethod =
       flow === 'implicit' ? 'initTokenClient' : 'initCodeClient';
 
-    const client = window?.google?.accounts.oauth2[clientMethod]({
+    const client = window?.google?.accounts?.oauth2[clientMethod]({
       client_id: clientId,
       scope: overrideScope ? scope : `openid profile email ${scope}`,
       callback: (response: TokenResponse | CodeResponse) => {


### PR DESCRIPTION
Fix issues when reading .oauth2 throws errors if accounts is undefined