### PR TITLE
fix: width prop is now parsed as a number

### DIFF
--- a/.changeset/four-mails-smash.md
+++ b/.changeset/four-mails-smash.md
@@ -1,0 +1,5 @@
+---
+'@react-oauth/google': patch
+---
+
+Width prop is for GoogleLogin component is now parsed as a number

--- a/packages/@react-oauth/google/src/GoogleLogin.tsx
+++ b/packages/@react-oauth/google/src/GoogleLogin.tsx
@@ -32,7 +32,7 @@ export default function GoogleLogin({
   text,
   shape,
   logo_alignment,
-  width,
+  width: _width,
   locale,
   click_listener,
   containerProps,
@@ -70,6 +70,16 @@ export default function GoogleLogin({
       ...props,
     });
 
+    let width: number | undefined;
+    if (typeof _width === 'string') {
+      width = parseInt(_width);
+    } else {
+      width = _width;
+    }
+
+    if (width && isNaN(width))
+      throw new Error('GoogleLogin: width prop must be a number');
+
     window?.google?.accounts?.id?.renderButton(btnContainerRef.current!, {
       type,
       theme,
@@ -99,7 +109,7 @@ export default function GoogleLogin({
     text,
     shape,
     logo_alignment,
-    width,
+    _width,
     locale,
   ]);
 

--- a/packages/@react-oauth/google/src/types/index.ts
+++ b/packages/@react-oauth/google/src/types/index.ts
@@ -85,7 +85,7 @@ export interface GsiButtonConfiguration {
   /**	The Google [logo alignment](https://developers.google.com/identity/gsi/web/reference/js-reference#logo_alignment): left or center */
   logo_alignment?: 'left' | 'center';
   /** The button [width](https://developers.google.com/identity/gsi/web/reference/js-reference#width), in pixels */
-  width?: number;
+  width?: string | number;
   /** If set, then the button [language](https://developers.google.com/identity/gsi/web/reference/js-reference#locale) is rendered */
   locale?: string;
   /** If set, this [function](https://developers.google.com/identity/gsi/web/reference/js-reference#click_listener) will be called when the Sign in with Google button is clicked. */

--- a/packages/@react-oauth/google/src/types/index.ts
+++ b/packages/@react-oauth/google/src/types/index.ts
@@ -85,7 +85,7 @@ export interface GsiButtonConfiguration {
   /**	The Google [logo alignment](https://developers.google.com/identity/gsi/web/reference/js-reference#logo_alignment): left or center */
   logo_alignment?: 'left' | 'center';
   /** The button [width](https://developers.google.com/identity/gsi/web/reference/js-reference#width), in pixels */
-  width?: string | number;
+  width?: number;
   /** If set, then the button [language](https://developers.google.com/identity/gsi/web/reference/js-reference#locale) is rendered */
   locale?: string;
   /** If set, this [function](https://developers.google.com/identity/gsi/web/reference/js-reference#click_listener) will be called when the Sign in with Google button is clicked. */


### PR DESCRIPTION
When using a string the GoogleScript fails:

![image](https://github.com/MomenSherif/react-oauth/assets/8129679/f4c336bf-b305-43e1-bc3d-0d72864e58be)

It is now forcing to be a number:
![image](https://github.com/MomenSherif/react-oauth/assets/8129679/c43f0a8f-9df8-4028-aa2d-2f2f8ecfb767)

Instead of changing the prop to only allow a number, I coded to be backward compatible until we convert it into a breaking change.