### PR TITLE
fix: Fix error produced when passing width size to GoogleLogin

### DIFF
--- a/packages/@react-oauth/google/src/GoogleLogin.tsx
+++ b/packages/@react-oauth/google/src/GoogleLogin.tsx
@@ -77,7 +77,7 @@ export default function GoogleLogin({
       text,
       shape,
       logo_alignment,
-      width,
+      width: typeof width !== 'number' ? width : `${width}px`,
       locale,
       click_listener,
     });

--- a/packages/@react-oauth/google/src/types/index.ts
+++ b/packages/@react-oauth/google/src/types/index.ts
@@ -85,7 +85,7 @@ export interface GsiButtonConfiguration {
   /**	The Google [logo alignment](https://developers.google.com/identity/gsi/web/reference/js-reference#logo_alignment): left or center */
   logo_alignment?: 'left' | 'center';
   /** The button [width](https://developers.google.com/identity/gsi/web/reference/js-reference#width), in pixels */
-  width?: string | number;
+  width?: WidthType | number;
   /** If set, then the button [language](https://developers.google.com/identity/gsi/web/reference/js-reference#locale) is rendered */
   locale?: string;
   /** If set, this [function](https://developers.google.com/identity/gsi/web/reference/js-reference#click_listener) will be called when the Sign in with Google button is clicked. */
@@ -366,3 +366,6 @@ export interface CodeClientConfig {
 export type MomentListener = (
   promptMomentNotification: PromptMomentNotification,
 ) => void;
+
+type WidthUnit = 'px';
+type WidthType = `${number}${WidthUnit}`;


### PR DESCRIPTION
When user passed width to GoogleLogin, they might forget to put the px, it throws an error message to the client but the msg was unclear. I tried to put number as well but typescript gave warning that type 'number' can't be put to 'string'. This PR handled the error by asking user to add px to the width if they wanted to put it as string and handle the 'number' is not 'string' issue by converting the number to string px.

Error Screenshot:
![image](https://github.com/MomenSherif/react-oauth/assets/53996155/5d681bc5-d6be-4a4d-9f30-863f933a6cd3)
