### PR TITLE
docs(readme.md): add token exchange info

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ const login = useGoogleLogin({
 <MyCustomButton onClick={() => login()}>Sign in with Google 🚀</MyCustomButton>;
 ```
 
+### Exchange authorization code for tokens (backend)
+
+[Google Docs](https://developers.google.com/identity/protocols/oauth2/web-server#exchange-authorization-code){:target="_blank"}
+
 #### Checks if the user granted all the specified scope or scopes
 
 ```jsx


### PR DESCRIPTION
Adding a link to google docs to let users know how to exchange the auth code. The guide website has node but the Google doc demonstrates how to do this in php, python, ruby, node, and http/rest. This addition would make the user's next steps in the process smoother.