### PR TITLE
fix: include hl directive into script tag if locale is passed

### DIFF
--- a/packages/@react-oauth/google/src/GoogleLogin.tsx
+++ b/packages/@react-oauth/google/src/GoogleLogin.tsx
@@ -33,13 +33,12 @@ export default function GoogleLogin({
   shape,
   logo_alignment,
   width,
-  locale,
   click_listener,
   containerProps,
   ...props
 }: GoogleLoginProps) {
   const btnContainerRef = useRef<HTMLDivElement>(null);
-  const { clientId, scriptLoadedSuccessfully } = useGoogleOAuth();
+  const { clientId, locale, scriptLoadedSuccessfully } = useGoogleOAuth();
 
   const onSuccessRef = useRef(onSuccess);
   onSuccessRef.current = onSuccess;

--- a/packages/@react-oauth/google/src/GoogleOAuthProvider.tsx
+++ b/packages/@react-oauth/google/src/GoogleOAuthProvider.tsx
@@ -6,6 +6,7 @@ import useLoadGsiScript, {
 
 interface GoogleOAuthContextProps {
   clientId: string;
+  locale?: string;
   scriptLoadedSuccessfully: boolean;
 }
 
@@ -19,6 +20,7 @@ interface GoogleOAuthProviderProps extends UseLoadGsiScriptOptions {
 export default function GoogleOAuthProvider({
   clientId,
   nonce,
+  locale,
   onScriptLoadSuccess,
   onScriptLoadError,
   children,
@@ -27,10 +29,12 @@ export default function GoogleOAuthProvider({
     nonce,
     onScriptLoadSuccess,
     onScriptLoadError,
+    locale,
   });
 
   const contextValue = useMemo(
     () => ({
+      locale,
       clientId,
       scriptLoadedSuccessfully,
     }),

--- a/packages/@react-oauth/google/src/google-auth-window.d.ts
+++ b/packages/@react-oauth/google/src/google-auth-window.d.ts
@@ -16,7 +16,7 @@ declare global {
           prompt: (momentListener?: MomentListener) => void;
           renderButton: (
             parent: HTMLElement,
-            options: GsiButtonConfiguration,
+            options: GsiButtonConfiguration & { locale?: string },
           ) => void;
           disableAutoSelect: () => void;
           storeCredential: (

--- a/packages/@react-oauth/google/src/hooks/useLoadGsiScript.ts
+++ b/packages/@react-oauth/google/src/hooks/useLoadGsiScript.ts
@@ -6,6 +6,10 @@ export interface UseLoadGsiScriptOptions {
    */
   nonce?: string;
   /**
+   * ISO-639 code of [locale](https://developers.google.com/identity/gsi/web/reference/js-reference#locale) to use for content
+   */
+  locale?: string;
+  /**
    * Callback fires on load [gsi](https://accounts.google.com/gsi/client) script success
    */
   onScriptLoadSuccess?: () => void;
@@ -18,7 +22,7 @@ export interface UseLoadGsiScriptOptions {
 export default function useLoadGsiScript(
   options: UseLoadGsiScriptOptions = {},
 ): boolean {
-  const { nonce, onScriptLoadSuccess, onScriptLoadError } = options;
+  const { nonce, locale, onScriptLoadSuccess, onScriptLoadError } = options;
 
   const [scriptLoadedSuccessfully, setScriptLoadedSuccessfully] =
     useState(false);
@@ -32,6 +36,7 @@ export default function useLoadGsiScript(
   useEffect(() => {
     const scriptTag = document.createElement('script');
     scriptTag.src = 'https://accounts.google.com/gsi/client';
+    if (locale) scriptTag.src += `?hl=${locale}`;
     scriptTag.async = true;
     scriptTag.defer = true;
     scriptTag.nonce = nonce;

--- a/packages/@react-oauth/google/src/types/index.ts
+++ b/packages/@react-oauth/google/src/types/index.ts
@@ -91,8 +91,6 @@ export interface GsiButtonConfiguration {
   logo_alignment?: 'left' | 'center';
   /** The button [width](https://developers.google.com/identity/gsi/web/reference/js-reference#width), in pixels */
   width?: string | number;
-  /** If set, then the button [language](https://developers.google.com/identity/gsi/web/reference/js-reference#locale) is rendered */
-  locale?: string;
   /** If set, this [function](https://developers.google.com/identity/gsi/web/reference/js-reference#click_listener) will be called when the Sign in with Google button is clicked. */
   click_listener?: () => void;
 }


### PR DESCRIPTION
## Context

- https://github.com/MomenSherif/react-oauth/issues/56

The reason why this doesn't work according to Google's documentation is that the library doesn't pass the `hl` directive

> Add the hl parameter and language code to the src directive when loading the library, for example: gsi/client?hl=\<iso-639-code\>
>
>If it's not set, the browser's default locale or the Google session user's preference is used

## Changes

This PR introduces a new `locale` prop on the `<GoogleOAuthProvider />` component instead of the button itself, as this way it can now be included in the script tag. At the same time, the old prop on the `<GoogleLogin />` button is no longer needed and has been removed. This is **not backwards compatible**, so it will probably have to wait until the next major.

## Workaround

```jsx
  const onScriptLoaded = () => {
    document.body.removeChild(document.querySelector('[src="https://accounts.google.com/gsi/client"]'));
    const scriptTag = document.createElement('script');
    scriptTag.src = `https://accounts.google.com/gsi/client?hl=${locale}`;
    scriptTag.onload = () => {
      setIsReady(true);
    };
    document.body.appendChild(scriptTag);
  };

  return (
    <div ref={ref}>
      <GoogleOAuthProvider
        clientId={googleSignInToken}
        onScriptLoadSuccess={onScriptLoaded}
      >
        {isReady && <GoogleLogin {...props} />}
      </GoogleOAuthProvider>
    </div>
  );
```

